### PR TITLE
Fixes Issue #856 IPv6 check failure

### DIFF
--- a/tests/golem/core/test_hostaddress.py
+++ b/tests/golem/core/test_hostaddress.py
@@ -38,9 +38,16 @@ def is_ip_address(address):
     from ipaddress import ip_address, AddressValueError
     try:
         # will raise error in case of incorrect address
-        ip_address(str(address))
+        s = str(address)
+        ip_address(s)
         return True
     except (ValueError, AddressValueError):
+        try:
+            # Check for local scope prefix and designator
+            ip_address(s.split('%')[0])
+            return (s[0][:4].lower().startswith('fe80'))
+        except (ValueError, AddressValueError):
+            pass
         return False
 
 


### PR DESCRIPTION
The ipaddress module doesn't appear to support the local scope addressing.  As elsewhere in the code, this considers only the address itself, and only if it follows the convention for local-only addresses of using the 'fe80' prefix.